### PR TITLE
fix: set lean to true by default

### DIFF
--- a/controllers/accessories.js
+++ b/controllers/accessories.js
@@ -2,15 +2,15 @@ const Accessory = require('../models/accessory')
 const Cube = require('../models/cube')
 
 const getAccessories = async () => {
-  const accessories = await Accessory.find().lean()
+  const accessories = await Accessory.find();
 
   return accessories
 }
 
 const attachedAccessories = async (cubeId) => {
   try {
-    const cube = await Cube.findById(cubeId).lean()
-    const accessories = await Accessory.find({ cubes: { $nin: cubeId } }).lean()
+    const cube = await Cube.findById(cubeId);
+    const accessories = await Accessory.find({ cubes: { $nin: cubeId } });
     return { cube, accessories }
   } catch (err) {
     return err

--- a/controllers/cubes.js
+++ b/controllers/cubes.js
@@ -2,18 +2,18 @@ const Cube = require('../models/cube')
 const Accessory = require('../models/accessory')
 
 const getAllCubes = async () => {
-  const cubes = await Cube.find().lean()
+  const cubes = await Cube.find();
   return cubes
 }
 
 const getCube = async (id) => {
-  const cube = await Cube.findById(id).lean()
+  const cube = await Cube.findById(id);
 
   return cube
 }
 
 const getCubeWithAccessories = async (id) => {
-  const cube = await Cube.findById(id).populate('accessories').lean()
+  const cube = await Cube.findById(id).populate('accessories');
 
   return cube
 }

--- a/index.js
+++ b/index.js
@@ -10,6 +10,14 @@ const cubeRouter = require('./routes/cube')
 const accessoryRouter = require('./routes/accessory')
 const app = express()
 
+let __setOptions = mongoose.Query.prototype.setOptions;
+
+mongoose.Query.prototype.setOptions = function (options) {
+    __setOptions.apply(this, arguments);
+    if (this._mongooseOptions.lean == null) this._mongooseOptions.lean = true;
+    return this;
+};
+
 mongoose.connect(config.databaseUrl, {
   useNewUrlParser: true,
   useUnifiedTopology: true


### PR DESCRIPTION
After a ton of debugging the source code of mongoose I managed to monkey patch mongoose.Query so there's no need to ,,lean" the query every time, now it's done by default. 

_Example:_

*Without monkey patching:*
`const cubes = await Cube.find({}).lean()`

*With monkey patching:*
`const cubes = await Cube.find({})` //same output as with .lean()

It isn't a big change but I think it's pretty annoying to ,,lean" every time you want to get reliable data.
If the developer explicitly wants to set lean to false(not likely scenario), there will be no issues, because of the ,,if" check.
